### PR TITLE
Fix qopy chunks

### DIFF
--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -181,9 +181,10 @@ class QobuzDL:
                     skip_extras=True,
                 )
             else:
-                items = [item[type_dict["iterable_key"]]["items"] for item in content][
-                    0
-                ]
+                items = []
+                for chunk in content:
+                    batch = chunk.get(type_dict["iterable_key"], {}).get("items", [])
+                    items.extend(batch)
 
             logger.info(f"{YELLOW}{len(items)} downloads in queue")
             

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -186,6 +186,9 @@ class QobuzDL:
                     batch = chunk.get(type_dict["iterable_key"], {}).get("items", [])
                     items.extend(batch)
 
+            logger.debug(f"Number of chunks: {len(content)}")
+            if content:
+                logger.debug(f"Items in first chunk: {len(content[0].get(type_dict['iterable_key'], {}).get('items', []))}")
             logger.info(f"{YELLOW}{len(items)} downloads in queue")
             
             # --- START PLAYLIST LOGIC (Flat Folder) ---

--- a/qobuz_dl/qopy.py
+++ b/qobuz_dl/qopy.py
@@ -365,14 +365,25 @@ class Client:
         return self._normalize_json_strings(r.json())
 
     def multi_meta(self, epoint, key, id, type):
-        total, offset = 1, 0
-        while total > 0:
-            j = self.api_call(epoint, id=id, offset=offset, type=type)
+        offset = 0
+        limit = 50
+        
+        while True:
+            j = self.api_call(epoint, id=id, offset=offset, limit=limit, type=type)
             res = j[type] if type and type in j else j
+            
+            items_key = "tracks" if "playlist" in epoint else "albums"
+            items = res.get(items_key, {}).get("items", [])
+            
+            if not items:
+                break
+                
             yield res
-            if offset == 0: total = res.get(key, 0) - 500
-            else: total -= 500
-            offset += 500
+            
+            offset += len(items)
+            total_available = res.get(key, 0)
+            if offset >= total_available:
+                break
 
     # --- METADATA FUNCTIONS (Do not delete!) ---
     def get_track_meta(self, id): 


### PR DESCRIPTION
This PR resolves the issue where the Qobuz API returns only 50 entries per "chunk," whereas the code assumed that 500 entries would be returned per chunk.

Before my changes, it was only possible to download 50 tracks from the first 500 tracks in a playlist.