### PR TITLE
 Fix Playlist Flat Folder Overrides, Invalid Track Formatting, and CLI Purge Crash

### DIFF
--- a/qobuz_dl/cli.py
+++ b/qobuz_dl/cli.py
@@ -86,7 +86,7 @@ def _reset_config(config_file):
     config["qobuz"]["secrets"] = ",".join(bundle.get_secrets().values())
 
     # Removed old folder_format override that caused custom format resets
-    config["qobuz"]["track_format"] = "{tracknumber} {tracktitle}"
+    config["qobuz"]["track_format"] = "{track_number} - {track_title}"
     config["qobuz"]["fallback_folder_format"] = "{artist} - {album}"
     config["qobuz"]["smart_discography"] = "false"
 
@@ -265,7 +265,6 @@ def main():
     if getattr(arguments, 'sync_db', None):
         from qobuz_dl.sync import sync_database
         from qobuz_dl.qopy import Client
-        from qobuz_dl.color import GREEN, OFF
         
         # Inizializza un client API leggero per il Reverse Lookup (ignora il downloader pesante)
         sync_client = Client(email, password, app_id, secrets, user_auth_token=token, force_english=force_english)

--- a/qobuz_dl/core.py
+++ b/qobuz_dl/core.py
@@ -60,7 +60,7 @@ class QobuzDL:
         downloads_db=None,
         folder_format="{artist} - {album} ({year}) [{bit_depth}B-"
         "{sampling_rate}kHz]",
-        track_format="{tracknumber}. {tracktitle}",
+        track_format="{track_number} - {track_title}",
         smart_discography=False,
         fetch_lyrics=False,
         genius_token=None,
@@ -191,14 +191,8 @@ class QobuzDL:
                 logger.debug(f"Items in first chunk: {len(content[0].get(type_dict['iterable_key'], {}).get('items', []))}")
             logger.info(f"{YELLOW}{len(items)} downloads in queue")
             
-            # --- START PLAYLIST LOGIC (Flat Folder) ---
+            # --- START PLAYLIST LOGIC ---
             is_playlist = (url_type == "playlist")
-            if is_playlist:
-                original_folder_format = self.folder_format
-                original_multi_disc_setting = self.settings.multiple_disc_one_dir
-                
-                self.folder_format = "."
-                self.settings.multiple_disc_one_dir = True
             # ------------------------------------------------
 
             # Use enumerate to get the track number in the playlist (1, 2, 3...)
@@ -211,10 +205,6 @@ class QobuzDL:
                     playlist_index=idx
                 )
 
-            # --- RESTORE SETTINGS ---
-            if is_playlist:
-                self.folder_format = original_folder_format
-                self.settings.multiple_disc_one_dir = original_multi_disc_setting
             # -------------------------------
 
             if url_type == "playlist" and not self.no_m3u_for_playlists:
@@ -545,13 +535,7 @@ class QobuzDL:
 
         # Step 3: Send valid IDs to the downloader engine
         
-        # Save original settings to restore them later
-        original_folder_format = self.folder_format
-        original_multi_disc_setting = self.settings.multiple_disc_one_dir
-        
-        # Force flat folder structure for the playlist
-        self.folder_format = "."
-        self.settings.multiple_disc_one_dir = True
+        # Use the standard folder format for the playlist
         
         # Use enumerate to get the playlist track number (1, 2, 3...)
         for idx, t_id in enumerate(track_ids, start=1):
@@ -565,10 +549,6 @@ class QobuzDL:
                 )
             except Exception as e:
                 logger.error(f"{RED}[!] Failed to queue track ID {t_id}: {e}{OFF}")
-
-        # Restore original settings for subsequent downloads
-        self.folder_format = original_folder_format
-        self.settings.multiple_disc_one_dir = original_multi_disc_setting
 
         if not self.no_m3u_for_playlists:
             make_m3u(pl_directory)

--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -322,11 +322,8 @@ class Download:
             dirn = process_folder_format_with_subdirs(self.folder_format, track_attr, self.path)
             os.makedirs(dirn, exist_ok=True)
 
-            # --- START PLAYLIST COVER FIX ---
-            if getattr(self, 'is_playlist', False):
-                # Skip saving the generic cover.jpg to avoid cluttering the folder with 50 different images
-                logger.info(f"{OFF}Skipping standard cover save to keep playlist folder clean")
-            elif self.settings.no_cover:
+            # --- STANDARD COVER LOGIC ---
+            if self.settings.no_cover:
                 logger.info(f"{OFF}Skipping cover")
             else:
                 _get_extra(track_meta["album"]["image"]["large"], dirn, art_size=self.settings.saved_art_size)


### PR DESCRIPTION
**Description**
This Pull Request addresses a few related bugs regarding how playlists are handled and saved locally, as well as fixing a CLI crash during database purging.

1. Playlist Flat Folder Override Removal (core.py)
**The Issue**: When downloading playlists, core.py historically forced self.folder_format = "." and self.settings.multiple_disc_one_dir = True to dump all tracks into a single flat directory. While this prevented deep directory trees, it inadvertently caused major conflicts. Specifically, tracks from different albums within the same playlist would constantly overwrite embed_cover.jpg and .lrc files, leading to a messy, disorganized directory with incorrect covers and lyrics assigned to the wrong files.

**The Fix**: Removed the hard-coded flat folder overrides in both handle_url and download_lastfm_pl. Playlist downloads will now respect the user's custom folder_format configuration, creating standard Artist - Album subfolders within the main Playlist directory. This ensures covers and lyrics are securely grouped by album without conflicts.

2. Invalid Track Variables in Config (cli.py & core.py)
**The Issue**: The default track_format was incorrectly initialized as {tracknumber} {tracktitle} in cli.py and core.py. The downloader engine expects {track_number} and {track_title}. The missing underscores caused an immediate KeyError: 'tracknumber' during the formatting stage inside _download_and_tag(), forcing the downloader to fall back to the generic fallback_folder_format and triggering unintended directory behaviors for Singles vs Albums.

**The Fix:** Corrected the default track initialization strings to use the proper internal dictionary keys: {track_number} - {track_title}.

3. UnboundLocalError during Database Purge (cli.py)
**The Issue:** Running qobuz-dl -p to purge the database would successfully delete the file but immediately crash with an UnboundLocalError: local variable 'GREEN' referenced before assignment. This happened because GREEN and OFF were locally imported inside main() under the sync_db logic, which shadowed the global imports of the same names.

**The Fix:** Removed the redundant local import from qobuz_dl.color import GREEN, OFF inside main(), allowing the global import at the top of the file to correctly colorize the exit message.



Testing Checklist
- [x] Tested downloading a playlist to verify album subfolders are properly created inside the playlist directory.
- [x] Verified embed_cover.jpg and .lrc files are grouped safely per album.
- [x] Verified the track_format is properly initialized on a fresh config generation without throwing KeyError.
- [x] Executed qobuz-dl -p to confirm the database purges cleanly without crashing.

----

This are some bugs I found while trying to download a playlist today. If this is not the expected behaviour of the app feel free to grab what you feel fits best.