### PR TITLE
Optimize artist handeling

### DIFF
--- a/qobuz_dl/downloader.py
+++ b/qobuz_dl/downloader.py
@@ -613,7 +613,10 @@ class Download:
             safe_print(f"{RED}[!] Error tagging: {e}{OFF}")
 
         if getattr(self, 'fetch_lyrics', False) and hasattr(self, 'lyrics_engine') and not abort_event.is_set():
-            search_artist = _safe_get(track_metadata, "performer", "name") or _safe_get(album_or_track_metadata, "artist", "name", default="Unknown")
+            album_artist = _safe_get(track_metadata, "album", "artist", "name")
+            performer_name = _safe_get(track_metadata, "performer", "name") or _safe_get(track_metadata, "artist", "name", default="Unknown")
+            search_artist = performer_name if album_artist in [None, "Various Artists"] else album_artist
+
             search_album = _safe_get(track_metadata, "album", "title", default="")
             
             with print_lock:

--- a/qobuz_dl/retro_tagger.py
+++ b/qobuz_dl/retro_tagger.py
@@ -40,7 +40,9 @@ def inject_lyrics_retroactively(directory_path, genius_token=None):
                             continue
                             
                         title = audio.get("TITLE", [""])[0]
-                        artist = audio.get("ARTIST", [""])[0]
+                        album_artist = audio.get("ALBUMARTIST", [""])[0]
+                        performer_name = audio.get("ARTIST", ["Unknown Artist"])[0]
+                        artist = performer_name if album_artist in ["", "Various Artists"] else album_artist
                         album = audio.get("ALBUM", [""])[0]
                         needs_lyrics = True
                         

--- a/qobuz_dl/sync_playlist.py
+++ b/qobuz_dl/sync_playlist.py
@@ -158,7 +158,9 @@ def sync_playlist(qobuz_dl, url, folder, auto_confirm=False):
         logger.info(f"\n{GREEN}Tracks to DOWNLOAD:{OFF}")
         for tid in sorted(to_download_ids):
             item = remote_ids[tid]
-            artist = item.get("performer", {}).get("name", "Unknown")
+            album_artist = item.get("album", {}).get("artist", {}).get("name")
+            performer_name = item.get("performer", {}).get("name", "Unknown")
+            artist = performer_name if album_artist in [None, "Various Artists"] else album_artist
             title = item.get("title", "Unknown")
             logger.info(f"  {GREEN}↓ {artist} — {title}{OFF}")
 

--- a/qobuz_dl/utils.py
+++ b/qobuz_dl/utils.py
@@ -128,7 +128,9 @@ def make_m3u(pl_directory, remote_items=None):
             tid = str(item.get("id", ""))
             isrc = str(item.get("isrc", ""))
             track_title = item.get("title", "Unknown Title")
-            performer_name = item.get("performer", {}).get("name", "Unknown Performer")
+            album_artist = item.get("album", {}).get("artist", {}).get("name")
+            performer_name = item.get("performer", {}).get("name", "Unknown Artist")
+            final_artist = performer_name if album_artist in [None, "Various Artists"] else album_artist
             
             # Pass 1-3: Fast dictionary lookups
             best_match = by_tid.get(tid) or by_isrc.get(isrc) or by_title.get(track_title.strip().lower())
@@ -147,7 +149,7 @@ def make_m3u(pl_directory, remote_items=None):
             else:
                 if missing_count == 0:
                     logger.warning(table_header)
-                row = f"{track_title[:35]:<35} │ {performer_name[:25]:<25} │ {tid:<12}"
+                row = f"{track_title[:35]:<35} │ {final_artist[:25]:<25} │ {tid:<12}"
                 logger.warning(f"{YELLOW}{row}{OFF}")
                 missing_count += 1
                 


### PR DESCRIPTION
The performer is not always the artist, get the album artist instead. The album artist can be "Various Artists", fallback to performer then.

This fixes the issue that lyrics cannot be found for a track, because the performer differs from the artist.
For example for the song "Seasons In The Sun (2023 Remaster) - Black Box Recorder" the performer is Luke Haines, so lyrics could not be found.

Please do not close & merge the changes by yourself this time. Thats not how open source works. I can apply review suggestions.